### PR TITLE
Fix group reset when updating. Fixes #35

### DIFF
--- a/src/main/java/com/casimirlab/simpleDeadlines/provider/DeadlineProvider.java
+++ b/src/main/java/com/casimirlab/simpleDeadlines/provider/DeadlineProvider.java
@@ -244,7 +244,8 @@ public class DeadlineProvider extends ContentProvider {
         if (MATCHER.match(uri) != MATCH_DEADLINE_ID)
             throw new IllegalArgumentException("Unknown or malformed URI. {uri: " + uri + "}");
 
-        if (TextUtils.isEmpty(values.getAsString(Deadlines.GROUP))) {
+        String groupString = values.getAsString(Deadlines.GROUP);
+        if ( groupString != null && TextUtils.getTrimmedLength( groupString) == 0) {
             SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(getContext());
             String group = sp.getString(
                     getContext().getString(R.string.pref_key_editor_group),


### PR DESCRIPTION
Prevent writing of whitespace string to Group name.
Preserve old group when `null` is passed.
Fixes #35 
